### PR TITLE
fix empty middleware array

### DIFF
--- a/src/ExportPostmanCollection.php
+++ b/src/ExportPostmanCollection.php
@@ -107,6 +107,10 @@ class ExportPostmanCollection extends Command
                     //GETTING @PARAMs @VARs @DESCRIPTIONs from PhpDoc comments
                     $p = $this->getParams($route);
                     //dd($p);
+                    
+                    if(empty($route->middleware()) {
+                        continue;
+                    }
 
                     //API ROUTES
                     if ($this->option('api') && "api" == $route->middleware()[0]) {


### PR DESCRIPTION
$route->middleware()[0] is a breaking assumption, sometimes it comes back as completely empty. Adding a skip if $route->middleware() is empty